### PR TITLE
Fixed the function tb-get-nic-model for SRIOV and MACVLAN modes

### DIFF
--- a/templates/iperf/run.sh.template
+++ b/templates/iperf/run.sh.template
@@ -73,7 +73,7 @@ nic=$(tb-get-nic-model REG_OVN_NIC_MODEL)
 arch=$(tb-get-cpu-model $OCP_WORKER_0)
 
 if [ "$TPL_SRIOV" == 1 ] ; then
-    nic=$(tb_get_nic_model REG_SRIOV_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_SRIOV_NIC_MODEL)
     source ${REG_ROOT}/SRIOV-config/config.env
     # New project. Recreate neworkAttachmentDefinition
     do_ssh $k8susr@$ocphost "kubectl config set-context --current --namespace=$OCP_PROJECT && kubectl apply -f ${REM_REG_ROOT}/${REG_SRIOV_NAD}"
@@ -85,7 +85,7 @@ if [ "$TPL_SRIOV" == 1 ] ; then
 fi
 
 if [ "$TPL_MACVLAN" == 1 ] ; then
-    nic=$(tb_get_nic_model REG_MACVLAN_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_MACVLAN_NIC_MODEL)
   	source ${REG_ROOT}/MACVLAN-config/config.env
     # New project. Recreate neworkAttachmentDefinition
     do_ssh $k8susr@$ocphost "kubectl config set-context --current --namespace=$OCP_PROJECT && kubectl apply -f ${REM_REG_ROOT}/${REG_MACVLAN_NAD}"

--- a/templates/mbench-official/run-3types-14pods.sh.template
+++ b/templates/mbench-official/run-3types-14pods.sh.template
@@ -69,7 +69,7 @@ nic=$(tb-get-nic-model REG_OVN_NIC_MODEL)
 arch=$(tb-get-cpu-model $OCP_WORKER_0)
 
 if [ "${TPL_SRIOV}" == 1  ]; then
-    nic=$(tb_get_nic_model REG_SRIOV_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_SRIOV_NIC_MODEL)
 	source ${REG_ROOT}/SRIOV-config/config.env
     DEST=$REG_KNI_USER@$REG_OCPHOST
     # New project. Recretate NAD
@@ -79,7 +79,7 @@ if [ "${TPL_SRIOV}" == 1  ]; then
 fi
 
 if [ "${TPL_MACVLAN}" == 1  ]; then
-    nic=$(tb_get_nic_model REG_MACVLAN_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_MACVLAN_NIC_MODEL)
 	source ${REG_ROOT}/MACVLAN-config/config.env
     DEST=$REG_KNI_USER@$REG_OCPHOST
     # New project. Recretate NAD

--- a/templates/mbench-official/run-3types.sh.template
+++ b/templates/mbench-official/run-3types.sh.template
@@ -63,7 +63,7 @@ nic=$(tb-get-nic-model REG_OVN_NIC_MODEL)
 arch=$(tb-get-cpu-model $OCP_WORKER_0)
 
 if [ "${TPL_SRIOV}" == 1  ]; then
-    nic=$(tb_get_nic_model REG_SRIOV_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_SRIOV_NIC_MODEL)
 	source ${REG_ROOT}/SRIOV-config/config.env
     DEST=$REG_KNI_USER@$REG_OCPHOST
     do_ssh ${DEST} "kubectl delete ns $OCP_PROJECT" &> /dev/null
@@ -76,7 +76,7 @@ if [ "${TPL_SRIOV}" == 1  ]; then
 fi
 
 if [ "${TPL_MACVLAN}" == 1  ]; then
-    nic=$(tb_get_nic_model REG_MACVLAN_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_MACVLAN_NIC_MODEL)
 	source ${REG_ROOT}/MACVLAN-config/config.env
     DEST=$REG_KNI_USER@$REG_OCPHOST
     do_ssh ${DEST} "kubectl delete ns $OCP_PROJECT" &> /dev/null

--- a/templates/mbench-small/run-3types.sh.template
+++ b/templates/mbench-small/run-3types.sh.template
@@ -61,7 +61,7 @@ fi
 nic=$(tb-get-nic-model REG_OVN_NIC_MODEL)
 arch=$(tb-get-cpu-model $OCP_WORKER_0)
 if [ "${TPL_SRIOV}" == 1  ]; then
-    nic=$(tb_get_nic_model REG_SRIOV_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_SRIOV_NIC_MODEL)
     source ${REG_ROOT}/SRIOV-config/config.env
     DEST=$REG_KNI_USER@$REG_OCPHOST
     do_ssh ${DEST} "kubectl delete ns $OCP_PROJECT" &> /dev/null

--- a/templates/uperf/run.sh.template
+++ b/templates/uperf/run.sh.template
@@ -75,7 +75,7 @@ nic=$(tb-get-nic-model REG_OVN_NIC_MODEL)
 arch=$(tb-get-cpu-model $OCP_WORKER_0)
 
 if [ "$TPL_SRIOV" == 1 ] ; then
-    nic=$(tb_get_nic_model REG_SRIOV_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_SRIOV_NIC_MODEL)
     source ${REG_ROOT}/SRIOV-config/config.env
     # New project. Recreate neworkAttachmentDefinition. 
     do_ssh $k8susr@$ocphost "kubectl config set-context --current --namespace=$OCP_PROJECT && kubectl apply -f ${REM_REG_ROOT}/${REG_SRIOV_NAD}"
@@ -95,7 +95,7 @@ fi
 
 
 if [ "$TPL_MACVLAN" == 1 ] ; then
-    nic=$(tb_get_nic_model REG_MACVLAN_NIC_MODEL)
+    nic=$(tb-get-nic-model REG_MACVLAN_NIC_MODEL)
   	source ${REG_ROOT}/MACVLAN-config/config.env
     # New project. Recreate neworkAttachmentDefinition. 
     do_ssh $k8susr@$ocphost "kubectl config set-context --current --namespace=$OCP_PROJECT && kubectl apply -f ${REM_REG_ROOT}/${REG_MACVLAN_NAD}"


### PR DESCRIPTION
While testing the SRIOV and MACVLAN test cases, Found the below error

```
run.sh: line 79: tb_get_nic_model: command not found
CMD: ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no root@10.X.X.X "bash -c 'kubectl config set-context --current --namespace=crucible-rickshaw && kubectl apply -f /root/REGULUS/regulus-cloud17-2025-12-09-16-53-30/./SRIOV-config/UNIV/generated_manifests/net-attach-def.yaml'"
```

```
rickshaw-run command: /opt/crucible/subprojects/core/rickshaw/rickshaw-run            --id f384eca3-e652-4607-b278-9a69fc4a7d42      --bench-dir /opt/crucible/subprojects/benchmarks/uperf      --engine-dir=/opt/crucible/subprojects/core/engine      --roadblock-dir=/opt/crucible/subprojects/core/roadblock      --roadblock-password=27db27730e77bf96ef6c3e6e8278bba9c59b183c16436ec883601766ae29df2c      --workshop-dir=/opt/crucible/subprojects/core/workshop      --packrat-dir=/opt/crucible/subprojects/core/packrat      --tools-dir=/opt/crucible/subprojects/tools      --registries-json=/opt/crucible/config/registries.json      --base-run-dir=/var/lib/crucible/run/uperf--2025-12-11_05:50:43_UTC--f384eca3-e652-4607-b278-9a69fc4a7d42      --external-userenvs-dir=/opt/crucible/subprojects/userenvs      --from-file /var/lib/crucible/run/uperf--2025-12-11_05:50:43_UTC--f384eca3-e652-4607-b278-9a69fc4a7d42/config/run-file.json
Creating run SSH key
Adding run SSH key as an authorized key
                                       ERROR: format for tag is not valid: nic:
Removing run SSH key as an authorized key
```

Able to fix the above errors after updating the function name properly.