### PR TITLE
Reload MCP environment variable before PAO test initialization

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ init-jobs: init-lab
 	echo JOBS=$$JOBS
 	@for dir in $(JOBS); do \
 		echo "Executing script in $$dir"; \
-		$(MAKE) -C $$dir init; \
+		. "$$REG_ROOT/bootstrap.sh" && $(MAKE) -C $$dir init; \
 	done
 
 clean-jobs: 


### PR DESCRIPTION
The PAO/INSTALL step modifies the MachineConfigPool (MCP) environment variable. This commit ensures the updated MCP is reloaded before initializing the PAO test cases to ensure they run against the correct configuration.